### PR TITLE
Added piping support to writeable streams

### DIFF
--- a/lib/request-jwt.js
+++ b/lib/request-jwt.js
@@ -37,15 +37,29 @@ exports.requestWithJWT = function (tokens, request) {
 	var interceptor = function (fn) {
 		return function (uri, options, callback) {
 			var params = request.initParams(uri, options, callback);
+			var res = params.res || null;
+
 			if (params.jwt) {
 				return tokens.get(params.jwt, function (err, token) {
 					if (err) return params.callback(err);
+
 					params.headers = params.headers || {};
 					params.headers.authorization = 'Bearer ' + token;
-					fn(params.uri || null, params, params.callback);
+
+					var request = fn(params.uri || null, params, params.callback);
+
+					if (res) {
+						request.pipe(res);
+					}
 				});
 			} else {
-				return fn(params.uri || null, params, params.callback);
+				var request = fn(params.uri || null, params, params.callback);
+
+				if (res) {
+					request.pipe(res);
+				}
+
+				return request;
 			}
 		};
 	};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-oauth-jwt",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "author": {
     "name": "Nicolas Mercier",
     "email": "nicolas@extrabacon.net"


### PR DESCRIPTION
Currently the library was buffering the response before we’re able to send the response anywhere.

Since I needed a highly-concurrent use of this, I patched the code to scratch my own itch :)

Happy to modify it, if you feel like there’s a better way of adding this feature.